### PR TITLE
fix: use grapheme cluster count instead of UTF-16 code units for animation resume index

### DIFF
--- a/lib/src/streaming/streaming_text.dart
+++ b/lib/src/streaming/streaming_text.dart
@@ -525,7 +525,7 @@ class _StreamingTextState extends State<StreamingText>
       units = Characters(widget.text).toList();
     }
 
-    final currentIndex = _displayedText.length;
+    final currentIndex = _displayedText.characters.length;
     _startCharacterByCharacterTypingFromIndex(units, currentIndex);
   }
 
@@ -549,7 +549,7 @@ class _StreamingTextState extends State<StreamingText>
       oldTextUnits = Characters(oldText).toList();
     }
 
-    final currentIndex = _displayedText.length;
+    final currentIndex = _displayedText.characters.length;
 
     // Continue animating the old text first, then the appended text
     _startCharacterByCharacterTypingFromIndexWithContinuation(


### PR DESCRIPTION
## Summary

- Fixes a bug where characters are dropped during streaming text animation when the text contains emoji or other multi-code-unit Unicode characters (surrogate pairs).
- In `_resumeCharacterByCharacterTyping` and `_resumeCharacterByCharacterTypingFromOldText`, `_displayedText.length` returns UTF-16 code units, but is used as an index into `Characters().toList()` which is indexed by grapheme clusters. For emoji (e.g. 👍, which is 2 UTF-16 code units but 1 grapheme), the index overshoots, skipping the next character.
- The fix replaces `_displayedText.length` with `_displayedText.characters.length` in these two methods.

## Reproduction

1. Stream text that contains emoji followed by more text (e.g. `"Great 👍 Keep going"`)
2. Ensure chunks arrive such that the animation is mid-progress when a new chunk appends
3. A character after the emoji is skipped in the displayed output

## Changes

Two lines in `lib/src/streaming/streaming_text.dart`:

| Method | Before | After |
|--------|--------|-------|
| `_resumeCharacterByCharacterTyping` | `_displayedText.length` | `_displayedText.characters.length` |
| `_resumeCharacterByCharacterTypingFromOldText` | `_displayedText.length` | `_displayedText.characters.length` |