### PR TITLE
add completeAnimationOnTap override behavior

### DIFF
--- a/lib/flutter_streaming_text_markdown.dart
+++ b/lib/flutter_streaming_text_markdown.dart
@@ -204,6 +204,12 @@ class StreamingTextMarkdown extends StatefulWidget {
   /// component list is used.
   final List<MarkdownComponent>? inlineComponents;
 
+  /// Whether tapping the widget jumps the animation to completion.
+  ///
+  /// Defaults to `true`. Set to `false` to let the animation play through
+  /// uninterrupted regardless of taps.
+  final bool? completeAnimationOnTap;
+
   const StreamingTextMarkdown({
     super.key,
     this.text = '',
@@ -241,6 +247,7 @@ class StreamingTextMarkdown extends StatefulWidget {
     this.linkBuilder,
     this.components,
     this.inlineComponents,
+    this.completeAnimationOnTap,
   });
 
   /// Creates a StreamingTextMarkdown with ChatGPT-style animation
@@ -276,6 +283,7 @@ class StreamingTextMarkdown extends StatefulWidget {
     this.linkBuilder,
     this.components,
     this.inlineComponents,
+    this.completeAnimationOnTap,
   })  : fadeInEnabled = true,
         fadeInDuration = const Duration(milliseconds: 150),
         fadeInCurve = Curves.easeOut,
@@ -316,6 +324,7 @@ class StreamingTextMarkdown extends StatefulWidget {
     this.linkBuilder,
     this.components,
     this.inlineComponents,
+    this.completeAnimationOnTap,
   })  : fadeInEnabled = true,
         fadeInDuration = const Duration(milliseconds: 200),
         fadeInCurve = Curves.easeInOut,
@@ -356,6 +365,7 @@ class StreamingTextMarkdown extends StatefulWidget {
     this.linkBuilder,
     this.components,
     this.inlineComponents,
+    this.completeAnimationOnTap,
   })  : fadeInEnabled = false,
         fadeInDuration = Duration.zero,
         fadeInCurve = Curves.linear,
@@ -396,6 +406,7 @@ class StreamingTextMarkdown extends StatefulWidget {
     this.linkBuilder,
     this.components,
     this.inlineComponents,
+    this.completeAnimationOnTap,
   })  : fadeInEnabled = false,
         fadeInDuration = Duration.zero,
         fadeInCurve = Curves.linear,
@@ -436,6 +447,7 @@ class StreamingTextMarkdown extends StatefulWidget {
     this.linkBuilder,
     this.components,
     this.inlineComponents,
+    this.completeAnimationOnTap,
   })  : fadeInEnabled = preset.fadeInEnabled,
         fadeInDuration = preset.fadeInDuration,
         fadeInCurve = preset.fadeInCurve,
@@ -521,6 +533,7 @@ class _StreamingTextMarkdownState extends State<StreamingTextMarkdown> {
           linkBuilder: widget.linkBuilder,
           components: widget.components,
           inlineComponents: widget.inlineComponents,
+          completeAnimationOnTap: widget.completeAnimationOnTap ?? true,
           onComplete: () {
             // Handle auto-scrolling
             if (mounted && widget.autoScroll && _scrollController.hasClients) {

--- a/lib/src/streaming/streaming_text.dart
+++ b/lib/src/streaming/streaming_text.dart
@@ -74,6 +74,7 @@ class StreamingText extends StatefulWidget {
     this.linkBuilder,
     this.components,
     this.inlineComponents,
+    this.completeAnimationOnTap = true,
   });
 
   final String text;
@@ -180,6 +181,12 @@ class StreamingText extends StatefulWidget {
   /// `gpt_markdown`'s `GptMarkdown.inlineComponents`. When `null`,
   /// `gpt_markdown`'s default inline component list is used.
   final List<MarkdownComponent>? inlineComponents;
+
+  /// Whether tapping the widget jumps the animation to completion.
+  ///
+  /// Defaults to `true`. Set to `false` to let the animation play through
+  /// uninterrupted regardless of taps.
+  final bool completeAnimationOnTap;
 
   @override
   State<StreamingText> createState() => _StreamingTextState();
@@ -1290,20 +1297,22 @@ class _StreamingTextState extends State<StreamingText>
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: () {
-        _typeTimer?.cancel();
-        _safeSetState(() {
-          _displayedTextBuffer.clear();
-          _displayedTextBuffer.write(widget.text);
-          _isComplete = true;
-          _isAnimationActive = false;
-        });
-        _handleCompletion();
-        // Force rebuild to process complete markdown
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          _safeSetState(() {});
-        });
-      },
+      onTap: widget.completeAnimationOnTap
+          ? () {
+              _typeTimer?.cancel();
+              _safeSetState(() {
+                _displayedTextBuffer.clear();
+                _displayedTextBuffer.write(widget.text);
+                _isComplete = true;
+                _isAnimationActive = false;
+              });
+              _handleCompletion();
+              // Force rebuild to process complete markdown
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                _safeSetState(() {});
+              });
+            }
+          : null,
       child: _buildContent(context),
     );
   }

--- a/test/flutter_streaming_text_markdown_test.dart
+++ b/test/flutter_streaming_text_markdown_test.dart
@@ -403,4 +403,70 @@ void main() {
       expect(completed, 1);
     });
   });
+
+  group('completeAnimationOnTap', () {
+    testWidgets('tap jumps animation to completion by default',
+        (tester) async {
+      var completed = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: StreamingTextMarkdown(
+            text: 'hello world this should take a while to type out',
+            typingSpeed: const Duration(milliseconds: 50),
+            fadeInEnabled: false,
+            onComplete: () => completed++,
+          ),
+        ),
+      );
+
+      // Let a couple of characters in, but nowhere near completion.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(completed, 0, reason: 'animation should still be running');
+
+      await tester.tap(find.byType(StreamingText));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(completed, 1,
+          reason: 'tap should short-circuit the animation and fire onComplete');
+    });
+
+    testWidgets(
+        'completeAnimationOnTap: false lets taps pass through without completing',
+        (tester) async {
+      var completed = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: StreamingTextMarkdown(
+            text: 'hello world this should take a while to type out',
+            typingSpeed: const Duration(milliseconds: 50),
+            fadeInEnabled: false,
+            completeAnimationOnTap: false,
+            onComplete: () => completed++,
+          ),
+        ),
+      );
+
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(completed, 0);
+
+      await tester.tap(find.byType(StreamingText));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(completed, 0,
+          reason: 'tap must not short-circuit the animation');
+
+      // Let the animation finish naturally; onComplete should still fire once.
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 50));
+      }
+      expect(completed, 1,
+          reason: 'natural completion should still fire onComplete exactly once');
+    });
+  });
 }


### PR DESCRIPTION
When the text is animating, tapping on the response jumps the animation to completion. I added a flag `completeAnimationOnTap` to allow a consumer to override this behavior.

```
  /// Whether tapping the widget jumps the animation to completion.
  ///
  /// Defaults to `true`. Set to `false` to let the animation play through
  /// uninterrupted regardless of taps.
  final bool? completeAnimationOnTap;
```